### PR TITLE
Resolve warning CS8625 in Board.cs

### DIFF
--- a/Chess-Challenge/src/Framework/Chess/Board/Board.cs
+++ b/Chess-Challenge/src/Framework/Chess/Board/Board.cs
@@ -68,7 +68,7 @@ namespace ChessChallenge.Chess
 
 
 
-        public Board(Board source = null)
+        public Board(Board? source = null)
         {
             if (source != null)
             {


### PR DESCRIPTION
When I ran the project I got a the warning: "CS8625: Cannot convert null literal to non-nullable reference type."
This PR simply marks the Board variable as nullable, so that warning disappears.