### PR TITLE
chg: add SyntaxKind.ReadOnlyKeyword to ignored tokens set

### DIFF
--- a/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
@@ -13,6 +13,7 @@ namespace ChessChallenge.Application
             SyntaxKind.PublicKeyword,
             SyntaxKind.SemicolonToken,
             SyntaxKind.CommaToken,
+            SyntaxKind.ReadOnlyKeyword,
             // only count open brace since I want to count the pair as a single token
             SyntaxKind.CloseBraceToken, 
             SyntaxKind.CloseBracketToken,


### PR DESCRIPTION
As explained in https://github.com/SebLague/Chess-Challenge/issues/65, I would very much appreciate if we could use _readonly_ without paying the price of 1 token for it.