### PR TITLE
Render the ranks and files on the edge cells, like Lichess does

### DIFF
--- a/Chess-Challenge/src/Framework/Application/UI/BoardTheme.cs
+++ b/Chess-Challenge/src/Framework/Application/UI/BoardTheme.cs
@@ -23,6 +23,9 @@ namespace ChessChallenge.Application
         public Color CheckDark = new Color(207, 39, 39, 255);
 
         public Color BorderCol = new Color(44, 44, 44, 255);
+
+        public Color LightCoordCol = new Color(255, 240, 220, 255);
+        public Color DarkCoordCol = new Color(140, 100, 80, 255);
     }
 }
 

--- a/Chess-Challenge/src/Framework/Application/UI/BoardUI.cs
+++ b/Chess-Challenge/src/Framework/Application/UI/BoardUI.cs
@@ -318,6 +318,23 @@ namespace ChessChallenge.Application
             {
                 DrawPiece(piece, new Vector2((int)pos.X, (int)pos.Y), alpha);
             }
+
+            int textSize = 25;
+            float xpadding = 5f, ypadding = 2f;
+            Color otherColor = coord.IsLightSquare() ? theme.DarkCoordCol : theme.LightCoordCol;
+            if (rank == 0) {
+                string fileLetter = "abcdefgh"[file].ToString();
+                UIHelper.DrawText(fileLetter,
+                    pos + new Vector2(xpadding, squareSize - ypadding),
+                    textSize, 123, otherColor,
+                    UIHelper.AlignH.Left, UIHelper.AlignV.Bottom);
+            }
+            if (file == 7) {
+                UIHelper.DrawText((rank + 1).ToString(),
+                    pos + new Vector2(squareSize - xpadding, ypadding),
+                    textSize, 123, otherColor,
+                    UIHelper.AlignH.Right, UIHelper.AlignV.Top);
+            }
         }
 
         Vector2 GetSquarePos(int file, int rank, bool whitePerspective)


### PR DESCRIPTION
I had a hard time reading the debug output from my algorithms because I can't instinctively look at a chess board and figure out what coordinates the different cells are.

This PR renders the ranks on the rightmost cells, and the files on the bottommost cells, like Lichess does.

Here's a nice screenshot:

![image](https://github.com/SebLague/Chess-Challenge/assets/29877714/df2f0d83-468e-4a43-a672-b4c090927f77)

I've made the text render with colors a little bit brighter/darker than the colors of the opposite cells to make it easier to read, given it doesn't look like there's a way to render text in bold.

I will probably open another PR soon so that `Move.ToString` prints the full algebraic notation of the name, including the piece.

(This has been a blast so far, by the way ... I've been mostly concentrating on ways to pack data into longs. Right now I have Sunfish's piece-state table implemented, without even any lookahead, and that's already beating me soundly. Further work is to implement the smallest bytecode interpreter I can and write a "real" chess algorithm in a condensed space...)