### PR TITLE
Add a helper method to print the SAN format of a given move.

### DIFF
--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -7,7 +7,7 @@ namespace ChessChallenge.API
 
 	public sealed class Board
 	{
-		readonly Chess.Board board;
+		readonly internal Chess.Board board;
 		readonly APIMoveGen moveGen;
 
 		readonly HashSet<ulong> repetitionHistory;

--- a/Chess-Challenge/src/API/Move.cs
+++ b/Chess-Challenge/src/API/Move.cs
@@ -59,6 +59,10 @@ namespace ChessChallenge.API
 			return $"Move: '{moveName}'";
 		}
 
+		public string GetSAN(Board board) {
+			return MoveUtility.GetMoveNameSAN(this.move, board.board);
+		}
+
 		/// <summary>
 		/// Tests if two moves are the same.
 		/// This is true if they move to/from the same square, and move/capture/promote the same piece type


### PR DESCRIPTION
For debugging purposes, given that MoveUtility isn't in the API namespace.