### PR TITLE
[Move Generation] Use stack allocation instead of heap allocation.

### DIFF
--- a/Chess-Challenge/src/Evil Bot/EvilBot.cs
+++ b/Chess-Challenge/src/Evil Bot/EvilBot.cs
@@ -12,15 +12,16 @@ namespace ChessChallenge.Example
 
         public Move Think(Board board, Timer timer)
         {
-            Move[] allMoves = board.GetLegalMoves();
+            Span<Move> moves = stackalloc Move[256];
+            int length = board.GetLegalMoves(ref moves);
 
             // Pick a random move to play if nothing better is found
             Random rng = new();
-            Move moveToPlay = allMoves[rng.Next(allMoves.Length)];
+            Move moveToPlay = moves[rng.Next(length)];
             int highestValueCapture = 0;
 
-            foreach (Move move in allMoves)
-            {
+            for (int i = 0; i < length; i++) {
+                Move move = moves[i];
                 // Always play checkmate in one
                 if (MoveIsCheckmate(board, move))
                 {

--- a/Chess-Challenge/src/Framework/Application/Helpers/API Helpers/APIMoveGen.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/API Helpers/APIMoveGen.cs
@@ -45,34 +45,32 @@ namespace ChessChallenge.Application.APIHelpers
         // If only captures should be generated, this will have 1s only in positions of enemy pieces.
         // Otherwise it will have 1s everywhere.
         ulong moveTypeMask;
-        API.Move[] moves;
 
         public APIMoveGen()
         {
             board = new Board();
-            moves = new API.Move[MaxMoves];
         }
 
         // Generates list of legal moves in current position.
         // Quiet moves (non captures) can optionally be excluded. This is used in quiescence search.
-        public API.Move[] GenerateMoves(Board board, bool includeQuietMoves = true)
+        public int GenerateMoves(Board board, ref Span<API.Move> moves, bool includeQuietMoves = true)
         {
             this.board = board;
             generateNonCapture = includeQuietMoves;
 
             Init();
 
-            GenerateKingMoves();
+            GenerateKingMoves(ref moves);
 
             // Only king moves are valid in a double check position, so can return early.
             if (!inDoubleCheck)
             {
-                GenerateSlidingMoves();
-                GenerateKnightMoves();
-                GeneratePawnMoves();
+                GenerateSlidingMoves(ref moves);
+                GenerateKnightMoves(ref moves);
+                GeneratePawnMoves(ref moves);
             }
 
-            return moves.AsSpan().Slice(0, currMoveIndex).ToArray();
+            return currMoveIndex;
         }
 
         // Note, this will only return correct value after GenerateMoves() has been called in the current position
@@ -123,7 +121,7 @@ namespace ChessChallenge.Application.APIHelpers
             return apiMove;
         }
 
-        void GenerateKingMoves()
+        void GenerateKingMoves(ref Span<API.Move> moves)
         {
             ulong legalMask = ~(opponentAttackMap | friendlyPieces);
             ulong kingMoves = Bits.KingMoves[friendlyKingSquare] & legalMask & moveTypeMask;
@@ -159,7 +157,7 @@ namespace ChessChallenge.Application.APIHelpers
             }
         }
 
-        void GenerateSlidingMoves()
+        void GenerateSlidingMoves(ref Span<API.Move> moves)
         {
             // Limit movement to empty or enemy squares, and must block check if king is in check.
             ulong moveMask = emptyOrEnemySquares & checkRayBitmask & moveTypeMask;
@@ -214,7 +212,7 @@ namespace ChessChallenge.Application.APIHelpers
         }
 
 
-        void GenerateKnightMoves()
+        void GenerateKnightMoves(ref Span<API.Move> moves)
         {
             int friendlyKnightPiece = PieceHelper.MakePiece(PieceHelper.Knight, board.MoveColour);
             // bitboard of all non-pinned knights
@@ -234,7 +232,7 @@ namespace ChessChallenge.Application.APIHelpers
             }
         }
 
-        void GeneratePawnMoves()
+        void GeneratePawnMoves(ref Span<API.Move> moves)
         {
             int pushDir = board.IsWhiteToMove ? 1 : -1;
             int pushOffset = pushDir * 8;
@@ -325,7 +323,7 @@ namespace ChessChallenge.Application.APIHelpers
                     int startSquare = targetSquare - pushOffset;
                     if (!IsPinned(startSquare))
                     {
-                        GeneratePromotions(startSquare, targetSquare);
+                        GeneratePromotions(startSquare, targetSquare, ref moves);
                     }
                 }
             }
@@ -338,7 +336,7 @@ namespace ChessChallenge.Application.APIHelpers
 
                 if (!IsPinned(startSquare) || alignMask[startSquare, friendlyKingSquare] == alignMask[targetSquare, friendlyKingSquare])
                 {
-                    GeneratePromotions(startSquare, targetSquare);
+                    GeneratePromotions(startSquare, targetSquare, ref moves);
                 }
             }
 
@@ -349,7 +347,7 @@ namespace ChessChallenge.Application.APIHelpers
 
                 if (!IsPinned(startSquare) || alignMask[startSquare, friendlyKingSquare] == alignMask[targetSquare, friendlyKingSquare])
                 {
-                    GeneratePromotions(startSquare, targetSquare);
+                    GeneratePromotions(startSquare, targetSquare, ref moves);
                 }
             }
 
@@ -380,7 +378,7 @@ namespace ChessChallenge.Application.APIHelpers
             }
         }
 
-        void GeneratePromotions(int startSquare, int targetSquare)
+        void GeneratePromotions(int startSquare, int targetSquare, ref Span<API.Move> moves)
         {
             moves[currMoveIndex++] = CreateAPIMove(startSquare, targetSquare, Move.PromoteToQueenFlag, PieceHelper.Pawn);
             // Don't generate non-queen promotions in q-search

--- a/Chess-Challenge/src/Framework/Application/Helpers/Tester.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/Tester.cs
@@ -165,7 +165,7 @@ namespace ChessChallenge.Application
             //var moves = boardAPI.GetLegalMoves();
             Span<API.Move> captures = stackalloc API.Move[APIMoveGen.MaxMoves];
             int length = boardAPI.GetLegalMoves(ref captures, true);
-            Assert(captures.Length == 4, "Captures wrong");
+            Assert(length == 4, "Captures wrong");
             int numTested = 0;
             for (int i = 0; i < length; i++) {
                 var c = captures[i];

--- a/Chess-Challenge/src/Framework/Application/Helpers/Tester.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/Tester.cs
@@ -1,6 +1,7 @@
 ﻿using ChessChallenge.API;
 using ChessChallenge.Chess;
 using System;
+using ChessChallenge.Application.APIHelpers;
 
 namespace ChessChallenge.Application
 {
@@ -162,11 +163,12 @@ namespace ChessChallenge.Application
             Assert(boardAPI.IsWhiteToMove, "Colour to move wrong");
 
             //var moves = boardAPI.GetLegalMoves();
-            var captures = boardAPI.GetLegalMoves(true);
+            Span<API.Move> captures = stackalloc API.Move[APIMoveGen.MaxMoves];
+            int length = boardAPI.GetLegalMoves(ref captures, true);
             Assert(captures.Length == 4, "Captures wrong");
             int numTested = 0;
-            foreach (var c in captures)
-            {
+            for (int i = 0; i < length; i++) {
+                var c = captures[i];
                 if (c.TargetSquare.Index == 57)
                 {
                     Assert(c.StartSquare == new Square(0, 6), "Start square wrong");
@@ -229,14 +231,15 @@ namespace ChessChallenge.Application
 
         static ulong Search(int depth)
         {
-            var moves = boardAPI.GetLegalMoves();
+            Span<API.Move> moves = stackalloc API.Move[APIMoveGen.MaxMoves];
+            int length = boardAPI.GetLegalMoves(ref moves);
 
             if (depth == 1)
             {
-                return (ulong)moves.Length;
+                return (ulong)length;
             }
             ulong numLocalNodes = 0;
-            for (int i = 0; i < moves.Length; i++)
+            for (int i = 0; i < length; i++)
             {
 
                 boardAPI.MakeMove(moves[i]);

--- a/Chess-Challenge/src/Framework/Application/Helpers/Warmer.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/Warmer.cs
@@ -1,4 +1,6 @@
-﻿using ChessChallenge.API;
+﻿using System;
+using ChessChallenge.API;
+using ChessChallenge.Application.APIHelpers;
 
 namespace ChessChallenge.Application
 {
@@ -10,7 +12,8 @@ namespace ChessChallenge.Application
             Chess.Board b = new();
             b.LoadStartPosition();
             Board board = new Board(b);
-            Move[] moves = board.GetLegalMoves();
+            Span<Move> moves = stackalloc Move[APIMoveGen.MaxMoves];
+            board.GetLegalMoves(ref moves);
 
             board.MakeMove(moves[0]);
             board.UndoMove(moves[0]);

--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -1,10 +1,12 @@
-﻿using ChessChallenge.API;
+﻿using System;
+using ChessChallenge.API;
 
 public class MyBot : IChessBot
 {
     public Move Think(Board board, Timer timer)
     {
-        Move[] moves = board.GetLegalMoves();
+        Span<Move> moves = stackalloc Move[256];
+        board.GetLegalMoves(ref moves);
         return moves[0];
     }
 }


### PR DESCRIPTION
# Summary

This PR serves as a fix for #188. It makes all necessary changes to allow users to use stack allocation for their move lists while maintaining the API in its current state wherever possible. While I believe other changes can be done to further speed up the API, they weren't the main objective of this PR and are left untouched wherever possible. 

Let me know your thoughts.

# Benchmarks

As requested, I ran the popular [PERFT](https://www.chessprogramming.org/Perft) on both versions of the PR. This is a very popular test for move generation correctness and performance benchmarking (and although it doesn't do justice to the issue since we will never reach a high enough depth in PERFT as we do in search due to pruning), I still felt as if it was reasonable to do and speed gains would be visible. As with all benchmarks, speedups may differ depending on hardware. It's why I noted down the hardware in the results below.

The results were:
```
Position: Starting Chess Position (rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1)
Depth: 7

Current Master:     Searched 3195901860 nodes in 39585ms (Speed: ~  80.7Mnps)
Stackalloc Changes: Searched 3195901860 nodes in 20856ms (Speed: ~ 153.2Mnps)
Speedup: ~ 1.87x speed of current master.

Hardware: i9-11900H
```

Before you think, "Not even 2x the speed," - do note that in the relevant issue, a depth over 17 was reached during QSearch. In this case, we're not hitting even a depth of 8 (since it would take too long due to a lack of pruning). The more you increase the depth, the bigger the speedup will be, increasing with respect to the branching factor.

For the test, the following configuration was run for the base version (current master)
```cs
using System;
using System.Diagnostics;
using System.Runtime.CompilerServices;
using ChessChallenge.Chess;
using Move = ChessChallenge.API.Move;

namespace ChessChallenge.My_Bot;

public class Perft
{

    public static void Run()
    {
        Board board = new();
        board.LoadStartPosition();

        const int depth = 7;
        
        Console.WriteLine($"Perft to depth {depth}...");
        
        ChessChallenge.API.Board apiBoard = new(board);

        ulong nodes = 0;
        nodes = Internal(apiBoard, depth - 5);
        nodes = Internal(apiBoard, depth - 4);
        nodes = Internal(apiBoard, depth - 3);
        
        Stopwatch watch = new();
        watch.Start();
        nodes = Internal(apiBoard, depth);
        watch.Stop();
        
        Console.WriteLine("Searched {0} nodes in {1}ms", nodes, watch.ElapsedMilliseconds);
    }

    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
    private static ulong Internal(ChessChallenge.API.Board board, int depth)
    {
        if (depth == 1)
            return (ulong)board.GetLegalMoves().Length;
        
        ulong nodes = 0;
        
        Move[] moves = board.GetLegalMoves();
        
        foreach (Move move in moves) {
            board.MakeMove(move);
            nodes += Internal(board, depth - 1);
            board.UndoMove(move);
        }
        
        return nodes;
    }

}
```
and an altered version, adhering to the changes in this PR was run for my changes:
```cs
using System;
using System.Diagnostics;
using System.Runtime.CompilerServices;
using ChessChallenge.Chess;

namespace ChessChallenge.My_Bot;

public class Perft
{

    public static void Run()
    {
        Board board = new();
        board.LoadStartPosition();

        const int depth = 7;
        
        Console.WriteLine($"Perft to depth {depth}...");
        
        ChessChallenge.API.Board apiBoard = new(board);

        ulong nodes = 0;
        nodes = Internal(apiBoard, depth - 5);
        nodes = Internal(apiBoard, depth - 4);
        nodes = Internal(apiBoard, depth - 3);
        
        Stopwatch watch = new();
        watch.Start();
        nodes = Internal(apiBoard, depth);
        watch.Stop();
        
        Console.WriteLine("Searched {0} nodes in {1}ms", nodes, watch.ElapsedMilliseconds);
    }

    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
    private static ulong Internal(ChessChallenge.API.Board board, int depth)
    {
        Span<ChessChallenge.API.Move> moves = stackalloc ChessChallenge.API.Move[128];

        if (depth == 1)
            return (ulong)board.GetLegalMoves(ref moves);
        
        ulong nodes = 0;
        
        int moveCount = board.GetLegalMoves(ref moves);
        
        for (int i = 0; i < moveCount; i++)
        {
            ChessChallenge.API.Move move = moves[i];
            board.MakeMove(move);
            nodes += Internal(board, depth - 1);
            board.UndoMove(move);
        }
        
        return nodes;
    }

}
```