### PR TITLE
fix: allow for newline at end of Fens.txt file

### DIFF
--- a/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
+++ b/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
@@ -3,6 +3,7 @@ using ChessChallenge.Example;
 using Raylib_cs;
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
@@ -66,7 +67,7 @@ namespace ChessChallenge.Application
 
             BotStatsA = new BotMatchStats("IBot");
             BotStatsB = new BotMatchStats("IBot");
-            botMatchStartFens = FileHelper.ReadResourceFile("Fens.txt").Split('\n');
+            botMatchStartFens = FileHelper.ReadResourceFile("Fens.txt").Split('\n').Where(fen => fen.Length > 0).ToArray();
             botTaskWaitHandle = new AutoResetEvent(false);
 
             StartNewGame(PlayerType.Human, PlayerType.MyBot);


### PR DESCRIPTION
Hi, I am making this Pull Request to allow for empty lines in the `Fens.txt` file.

Why is this important? Some text editors (such as nvim) automatically add a `\n` at the end of files when saving them.  If such a file is used, the program will try to do 2 more matches against bots, because the array `botMatchStartFens[]` will have an empty entry at the end. This causes the program to get stuck.

This simple fix adresses this, while also allowing for empty lines anywhere in the file.
(I noticed this while trying to automate an automatic benchmark, you can see the result here: [Benchmark in 3 Minutes](https://github.com/joshuajeschek/Chess-Challenge/actions/runs/5632535128))