### PR TITLE
Protected and Internal access modifiers now ignored.

### DIFF
--- a/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
@@ -11,6 +11,8 @@ namespace ChessChallenge.Application
         {
             SyntaxKind.PrivateKeyword,
             SyntaxKind.PublicKeyword,
+            SyntaxKind.ProtectedKeyword,
+            SyntaxKind.InternalKeyword,
             SyntaxKind.SemicolonToken,
             SyntaxKind.CommaToken,
             SyntaxKind.ReadOnlyKeyword,


### PR DESCRIPTION
The [C# Docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/access-modifiers) mention that the protected and internal keywords are also access modifiers, yet in the application they are both counted as tokens despite the rules stating that access modifiers shouldn't be. I simply added the keywords onto the tokensToIgnore hash set to fix the issue.