### PR TITLE
Fix repetition detection

### DIFF
--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -11,6 +11,7 @@ namespace ChessChallenge.API
 		readonly Chess.Board board;
 		readonly APIMoveGen moveGen;
 
+		readonly HashSet<ulong> repetitionHistory;
 		readonly PieceList[] allPieceLists;
 		readonly PieceList[] validPieceLists;
 

--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -170,16 +170,21 @@ namespace ChessChallenge.API
 
         /// <summary>
         /// Test if the current position is a draw due stalemate, repetition, insufficient material, or 50-move rule.
-        /// Note: this function will return true if the same position has occurred twice on the board (rather than 3 times,
-        /// which is when the game is actually drawn). This quirk is to help bots avoid repeating positions unnecessarily.
         /// </summary>
         public bool IsDraw()
 		{
-			return IsFiftyMoveDraw() || IsInsufficientMaterial() || IsInStalemate() || IsRepeatedPosition();
+			return IsFiftyMoveDraw() || IsInsufficientMaterial() || IsInStalemate() || IsThreefoldRepetition();
 
 			bool IsInStalemate() => !IsInCheck() && GetLegalMoves().Length == 0;
 			bool IsFiftyMoveDraw() => board.currentGameState.fiftyMoveCounter >= 100;
 		}
+
+		/// <summary>
+		/// Test if the current position has occurred at least twice before on the board.
+		/// This includes both positions in the actual game, and positions reached by
+		/// making moves while the bot is thinking.
+		/// </summary>
+		public bool IsThreefoldRepetition() => board.RepetitionPositionHistory.Count((x => x == board.ZobristKey)) == 3;
 
 		/// <summary>
 		/// Test if the current position has occurred at least once before on the board.

--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -4,6 +4,7 @@ namespace ChessChallenge.API
 	using ChessChallenge.Chess;
 	using System;
 	using System.Collections.Generic;
+    using System.Linq;
 
 	public sealed class Board
 	{
@@ -174,7 +175,7 @@ namespace ChessChallenge.API
 
 			bool IsInStalemate() => !IsInCheck() && GetLegalMoves().Length == 0;
 			bool IsFiftyMoveDraw() => board.currentGameState.fiftyMoveCounter >= 100;
-			bool IsRepetition() => repetitionHistory.Contains(board.ZobristKey);
+			bool IsRepetition() => board.RepetitionPositionHistory.Count((x => x == board.currentGameState.zobristKey)) == 3;
 		}
 
 		/// <summary>

--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -11,7 +11,6 @@ namespace ChessChallenge.API
 		readonly Chess.Board board;
 		readonly APIMoveGen moveGen;
 
-		readonly HashSet<ulong> repetitionHistory;
 		readonly PieceList[] allPieceLists;
 		readonly PieceList[] validPieceLists;
 
@@ -45,10 +44,6 @@ namespace ChessChallenge.API
 				}
 			}
 			this.validPieceLists = validPieceLists.ToArray();
-
-			// Init rep history
-			repetitionHistory = new HashSet<ulong>(board.RepetitionPositionHistory);
-			repetitionHistory.Remove(board.ZobristKey);
 		}
 
 		/// <summary>
@@ -62,7 +57,6 @@ namespace ChessChallenge.API
 			hasCachedCaptureMoves = false;
 			if (!move.IsNull)
 			{
-				repetitionHistory.Add(board.ZobristKey);
 				board.MakeMove(new Chess.Move(move.RawValue), inSearch: true);
 			}
 		}
@@ -77,7 +71,6 @@ namespace ChessChallenge.API
 			if (!move.IsNull)
 			{
 				board.UndoMove(new Chess.Move(move.RawValue), inSearch: true);
-				repetitionHistory.Remove(board.ZobristKey);
 			}
 		}
 

--- a/Chess-Challenge/src/Framework/Chess/Board/Board.cs
+++ b/Chess-Challenge/src/Framework/Chess/Board/Board.cs
@@ -280,11 +280,8 @@ namespace ChessChallenge.Chess
             currentGameState = newState;
             hasCachedInCheckValue = false;
 
-            if (!inSearch)
-            {
-                RepetitionPositionHistory.Push(newState.zobristKey);
-                AllGameMoves.Add(move);
-            }
+            RepetitionPositionHistory.Push(newState.zobristKey);
+            AllGameMoves.Add(move);
         }
 
         // Undo a move previously made on the board
@@ -371,14 +368,11 @@ namespace ChessChallenge.Chess
             allPiecesBitboard = colourBitboards[WhiteIndex] | colourBitboards[BlackIndex];
             UpdateSliderBitboards();
 
-            if (!inSearch && RepetitionPositionHistory.Count > 0)
+            if (RepetitionPositionHistory.Count > 0)
             {
                 RepetitionPositionHistory.Pop();
             }
-            if (!inSearch)
-            {
-                AllGameMoves.RemoveAt(AllGameMoves.Count - 1);
-            }
+            AllGameMoves.RemoveAt(AllGameMoves.Count - 1);
 
             // Go back to previous state
             gameStateHistory.Pop();


### PR DESCRIPTION
As an attempt to resolve #170, this rewrites the API's `IsDraw -> IsRepetition` method to use `Chess.Board.RepetitionPositionHistory` like the Arbiter code does.

This requires permitting the RepetitionPositionHistory stack to be modified during search moves as well. Since I do not understand the logic behind not permitting that in the current code, I cannot say if this solution is acceptable.

Additionally, that change removes the only use of `API.Board.repetitionHistory`, so I have removed it.