### PR TITLE
Add a token count that excludes "Console.Write"s, making it easier to work within the token constraint while debugging

### DIFF
--- a/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
+++ b/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
@@ -52,7 +52,7 @@ namespace ChessChallenge.Application
         // Other
         readonly BoardUI boardUI;
         readonly MoveGenerator moveGenerator;
-        readonly int tokenCount;
+        readonly TokenCount tokenCount;
         readonly StringBuilder pgns;
 
         public ChallengeController()
@@ -215,7 +215,7 @@ namespace ChessChallenge.Application
             };
         }
 
-        static int GetTokenCount()
+        static TokenCount GetTokenCount()
         {
             string path = Path.Combine(Directory.GetCurrentDirectory(), "src", "My Bot", "MyBot.cs");
 

--- a/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
@@ -40,9 +40,8 @@ namespace ChessChallenge.Application
 
             foreach (var child in syntaxNode.ChildNodesAndTokens())
             {
-                //System.Console.WriteLine(child.ToString());
                 if (!(child.ToString().StartsWith("System.Console.Write") || child.ToString().StartsWith("Console.Write"))) {
-                    numTokensExcludingLogs += CountTokens(child).excludingLogs; // should work with total too as logs are top level it seems
+                    numTokensExcludingLogs += CountTokens(child).excludingLogs;
                 }
                 numTokensInChildren += CountTokens(child).total;
             }

--- a/Chess-Challenge/src/Framework/Application/UI/BotBrainCapacityUI.cs
+++ b/Chess-Challenge/src/Framework/Application/UI/BotBrainCapacityUI.cs
@@ -10,7 +10,7 @@ namespace ChessChallenge.Application
         static readonly Color red = new(219, 9, 9, 255);
         static readonly Color background = new Color(40, 40, 40, 255);
 
-        public static void Draw(int numTokens, int tokenLimit)
+        public static void Draw(TokenCount tokenCount, int tokenLimit)
         {
 
             int screenWidth = Raylib.GetScreenWidth();
@@ -20,7 +20,7 @@ namespace ChessChallenge.Application
             // Bg
             Raylib.DrawRectangle(0, screenHeight - height, screenWidth, height, background);
             // Bar
-            double t = (double)numTokens / tokenLimit;
+            double t = (double)tokenCount.total / tokenLimit;
 
             Color col;
             if (t <= 0.7)
@@ -34,8 +34,11 @@ namespace ChessChallenge.Application
             Raylib.DrawRectangle(0, screenHeight - height, (int)(screenWidth * t), height, col);
 
             var textPos = new System.Numerics.Vector2(screenWidth / 2, screenHeight - height / 2);
-            string text = $"Bot Brain Capacity: {numTokens}/{tokenLimit}";
-            if (numTokens > tokenLimit)
+            string text = $"Bot Brain Capacity: {tokenCount.total}/{tokenLimit}";
+            if (tokenCount.total != tokenCount.excludingLogs) {
+                text += $" (Excluding Logs: {tokenCount.excludingLogs})";
+            }
+            if (tokenCount.total > tokenLimit)
             {
                 text += " [LIMIT EXCEEDED]";
             }


### PR DESCRIPTION
This count is only visible when it differs from the total, and doesn't affect the limit exceeded message.

Code is not great nor robust, just a convenience tool.