### PR TITLE
Remove memory allocations in IsDraw

### DIFF
--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -172,7 +172,13 @@ namespace ChessChallenge.API
 		{
 			return IsFiftyMoveDraw() || Arbiter.InsufficentMaterial(board) || IsInStalemate() || IsRepetition();
 
-			bool IsInStalemate() => !IsInCheck() && GetLegalMoves().Length == 0;
+			bool IsInStalemate()
+			{
+				Span<Move> legalMoves = stackalloc Move[APIMoveGen.MaxMoves];
+				GetLegalMovesNonAlloc(ref legalMoves);
+				return !IsInCheck() && legalMoves.Length == 0;
+			}
+
 			bool IsFiftyMoveDraw() => board.currentGameState.fiftyMoveCounter >= 100;
 			bool IsRepetition() => repetitionHistory.Contains(board.ZobristKey);
 		}


### PR DESCRIPTION
The new version v1.13 provides a memory efficient way to generate moves. IsDraw uses the old version and allocates memory to detect stalemates. This simple fix use the new method.