### PR TITLE
Manual Move Undo and Human vs Human Mode

### DIFF
--- a/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
+++ b/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
@@ -8,6 +8,7 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using static ChessChallenge.Application.Settings;
 using static ChessChallenge.Application.ConsoleHelper;
 
@@ -73,6 +74,21 @@ namespace ChessChallenge.Application
             botTaskWaitHandle = new AutoResetEvent(false);
 
             StartNewGame(PlayerType.Human, PlayerType.MyBot);
+        }
+
+        public void UndoMoves(uint numToUndo)
+        {
+            List<Move> allMoves = board.AllGameMoves;
+            numToUndo = Math.Min((uint)allMoves.Count, numToUndo);
+
+            for (int i = 0; i < numToUndo; i++)
+            {
+                Move moveToUndo = allMoves.Last();
+                board.UndoMove(moveToUndo, false);
+            }
+
+            boardUI.UpdatePosition(board);
+            NotifyTurnToMove();
         }
 
         public void StartNewGame(PlayerType whiteType, PlayerType blackType)

--- a/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
+++ b/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
@@ -87,7 +87,8 @@ namespace ChessChallenge.Application
                 board.UndoMove(moveToUndo, false);
             }
 
-            boardUI.UpdatePosition(board);
+            var lastMove = (allMoves.Count == 0) ? new Move(0) : allMoves.Last() ;
+            boardUI.UpdatePosition(board, lastMove);
             NotifyTurnToMove();
         }
 
@@ -185,6 +186,12 @@ namespace ChessChallenge.Application
             {
                 PlayerToMove.Human.SetPosition(FenUtility.CurrentFen(board));
                 PlayerToMove.Human.NotifyTurnToMove();
+
+                if (PlayerNotToMove.IsHuman)
+                {
+                    // for the case of a human vs human match when a manual undo fires
+                    PlayerNotToMove.Human.CancelTurnToMove();
+                }
             }
             else
             {
@@ -431,7 +438,8 @@ namespace ChessChallenge.Application
         }
 
 
-        ChessPlayer PlayerToMove => board.IsWhiteToMove ? PlayerWhite : PlayerBlack;
+        ChessPlayer PlayerToMove    =>  (board.IsWhiteToMove) ? PlayerWhite : PlayerBlack;
+        ChessPlayer PlayerNotToMove => !(board.IsWhiteToMove) ? PlayerWhite : PlayerBlack;
         public int TotalGameCount => botMatchStartFens.Length * 2;
         public int CurrGameNumber => Math.Min(TotalGameCount, botMatchGameIndex + 1);
         public string AllPGNs => pgns.ToString();

--- a/Chess-Challenge/src/Framework/Application/Players/HumanPlayer.cs
+++ b/Chess-Challenge/src/Framework/Application/Players/HumanPlayer.cs
@@ -28,6 +28,11 @@ namespace ChessChallenge.Application
         {
             isTurnToMove = true;
         }
+        
+        public void CancelTurnToMove()
+        {
+            isTurnToMove = false;
+        }
 
         public void SetPosition(string fen)
         {

--- a/Chess-Challenge/src/Framework/Application/UI/MenuUI.cs
+++ b/Chess-Challenge/src/Framework/Application/UI/MenuUI.cs
@@ -9,12 +9,27 @@ namespace ChessChallenge.Application
     {
         public static void DrawButtons(ChallengeController controller)
         {
-            Vector2 buttonPos = UIHelper.Scale(new Vector2(260, 210));
+            Vector2 buttonPos = UIHelper.Scale(new Vector2(260, 144));
             Vector2 buttonSize = UIHelper.Scale(new Vector2(260, 55));
             float spacing = buttonSize.Y * 1.2f;
             float breakSpacing = spacing * 0.6f;
 
+            // Undo Button
+            if (controller.PlayerWhite.IsHuman || controller.PlayerBlack.IsHuman)
+            {
+                var undoNum = (controller.PlayerWhite.IsBot || controller.PlayerBlack.IsBot) ? 2 : 1 ;
+                if (NextButtonInRow("Undo Move", ref buttonPos, spacing, buttonSize))
+                {
+                    controller.UndoMoves((uint)undoNum);
+                }
+            } else {
+                buttonPos = UIHelper.Scale(new Vector2(260, 210));
+            }
+            
+
             // Game Buttons
+            buttonPos.Y += breakSpacing;
+
             if (NextButtonInRow("Human vs Human", ref buttonPos, spacing, buttonSize))
             {
                 controller.StartNewGame(ChallengeController.PlayerType.Human, ChallengeController.PlayerType.Human);

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ All names (variables, functions, etc.) are counted as a single token, regardless
   * This should launch the project. If not, open an issue with any error messages and relevant info.
 *  [Running on Linux](https://github.com/SebLague/Chess-Challenge/discussions/3)
 * Issues with illegal moves or errors when making/undoing a move
-  * Make sure that you are making and undoing moves in the correct order, and that you don't forget to undo a move when exitting early from a function for example.
+  * Make sure that you are making and undoing moves in the correct order, and that you don't forget to undo a move when exiting early from a function for example.
 * How to tell what colour MyBot is playing
   * You can look at `board.IsWhiteToMove` when the Think function is called
 * `GetPiece()` function is giving a null piece after making a move
   * Please make sure you are using the latest version of the project, there was a bug with this function in the original version
+* There is a community-run discord server [over here](https://github.com/SebLague/Chess-Challenge/discussions/156).
   


### PR DESCRIPTION
Implements #204 with a new manual undo button at the top of the button UI
Also implements #202 human vs human with thanks to @harrisi
Both features are implemented together since undo rolls back 1 move in HvH, and 2 moves in HvB (the bot's last move, and the human's last move).
Currently does not refund the thinkDuration spent calculating moves, since bots can cache calculation results. If refund is desired, we should probably store the think duration in the Move objects.