### PR TITLE
Ignore internal keyword

### DIFF
--- a/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
@@ -10,12 +10,13 @@ namespace ChessChallenge.Application
         static readonly HashSet<SyntaxKind> tokensToIgnore = new(new SyntaxKind[]
         {
             SyntaxKind.PrivateKeyword,
+            SyntaxKind.InternalKeyword,
             SyntaxKind.PublicKeyword,
             SyntaxKind.SemicolonToken,
             SyntaxKind.CommaToken,
             SyntaxKind.ReadOnlyKeyword,
             // only count open brace since I want to count the pair as a single token
-            SyntaxKind.CloseBraceToken, 
+            SyntaxKind.CloseBraceToken,
             SyntaxKind.CloseBracketToken,
             SyntaxKind.CloseParenToken
         });


### PR DESCRIPTION
Since both `public` and `private` keywords are ignored, why not ignoring `internal`?

Context:
Sometimes `internal` is used to facilitate tests projects to access fields/properties that you don't want to exposed in a public API using [`InternalsVisibleToAttribute`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute?view=net-7.0).