### PR TITLE
Ignore static keyword

### DIFF
--- a/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
@@ -13,9 +13,10 @@ namespace ChessChallenge.Application
             SyntaxKind.PublicKeyword,
             SyntaxKind.SemicolonToken,
             SyntaxKind.CommaToken,
+            SyntaxKind.StaticKeyword,
             SyntaxKind.ReadOnlyKeyword,
             // only count open brace since I want to count the pair as a single token
-            SyntaxKind.CloseBraceToken, 
+            SyntaxKind.CloseBraceToken,
             SyntaxKind.CloseBracketToken,
             SyntaxKind.CloseParenToken
         });


### PR DESCRIPTION
It'd be awesome to be able to mark functions, local functions and properties as static without wasting tokens, for performance reasons 😊