### PR TITLE
Added Board.OpponentRemainingMs : See #273

### DIFF
--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -20,6 +20,7 @@ namespace ChessChallenge.API
 		Move[] cachedLegalCaptureMoves;
 		bool hasCachedCaptureMoves;
         readonly Move[] movesDest;
+		public int OpponentRemainingMs = int.MaxValue;
 
         /// <summary>
         /// Create a new board. Note: this should not be used in the challenge,

--- a/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
+++ b/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
@@ -146,6 +146,8 @@ namespace ChessChallenge.Application
             try
             {
                 API.Timer timer = new(PlayerToMove.TimeRemainingMs);
+                botBoard.OpponentRemainingMs = PlayerNotToMove.TimeRemainingMs;
+                
                 API.Move move = PlayerToMove.Bot.Think(botBoard, timer);
                 return new Move(move.RawValue);
             }
@@ -413,7 +415,8 @@ namespace ChessChallenge.Application
         }
 
 
-        ChessPlayer PlayerToMove => board.IsWhiteToMove ? PlayerWhite : PlayerBlack;
+        ChessPlayer PlayerToMove    =>  (board.IsWhiteToMove) ? PlayerWhite : PlayerBlack;
+        ChessPlayer PlayerNotToMove => !(board.IsWhiteToMove) ? PlayerWhite : PlayerBlack;
         public int TotalGameCount => botMatchStartFens.Length * 2;
         public int CurrGameNumber => Math.Min(TotalGameCount, botMatchGameIndex + 1);
         public string AllPGNs => pgns.ToString();

--- a/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
+++ b/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
@@ -145,8 +145,8 @@ namespace ChessChallenge.Application
             API.Board botBoard = new(board);
             try
             {
-                API.Timer timer = new(PlayerToMove.TimeRemainingMs);
                 botBoard.OpponentRemainingMs = PlayerNotToMove.TimeRemainingMs;
+                API.Timer timer = new(PlayerToMove.TimeRemainingMs);
                 
                 API.Move move = PlayerToMove.Bot.Think(botBoard, timer);
                 return new Move(move.RawValue);


### PR DESCRIPTION
Addresses #273 by exposing the opponent's remaining milliseconds via a public int field in the Board class.
Access from the bot simply by calling `board.OpponentRemainingMs`
Changing this field will not impact the actual opponent remaining time, as it will only alter the botBoard object, which is discarded after the Think method completes.