### PR TITLE
Add optional parameter to TrySkipTurn to toggle whether it should abort if the current player is in check

### DIFF
--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -97,13 +97,13 @@ namespace ChessChallenge.API
 		}
 
 		/// <summary>
-		/// Try skip the current turn
-		/// This will fail and return false if in check
-		/// Note: skipping a turn is not allowed in the game, but it can be used as a search technique
+		/// Try to skip the current turn.
+		/// This will return false if in check (unless <paramref name="skipEvenIfInCheck"/> is set to true).
+		/// Note: skipping a turn is not allowed in the game, but it can be used as a search technique.
 		/// </summary>
-		public bool TrySkipTurn()
+		public bool TrySkipTurn(bool skipEvenIfInCheck = false)
 		{
-			if (IsInCheck())
+			if (!skipEvenIfInCheck && IsInCheck())
 			{
 				return false;
 			}


### PR DESCRIPTION
Fixes my own feature request https://github.com/SebLague/Chess-Challenge/issues/298.

The ```TrySkipTurn``` method currently won't switch over to the next player if the current one is in check. With this change you can decide for yourself if you want this behaviour or not. You can keep using ```TrySkipTurn()``` to avoid skipping on check as before, or you use ```TrySkipTurn(skipEvenIfInCheck: true)``` if you do not care about check.