### PR TITLE
Fix for bug in cachedInCheckValue when doing/undoing turnskips

### DIFF
--- a/Chess-Challenge/src/Framework/Chess/Board/Board.cs
+++ b/Chess-Challenge/src/Framework/Chess/Board/Board.cs
@@ -400,8 +400,7 @@ namespace ChessChallenge.Chess
             currentGameState = newState;
             gameStateHistory.Push(currentGameState);
             UpdateSliderBitboards();
-            hasCachedInCheckValue = true;
-            cachedInCheckValue = false;
+            hasCachedInCheckValue = false;
         }
 
         public void UnmakeNullMove()
@@ -412,8 +411,7 @@ namespace ChessChallenge.Chess
             gameStateHistory.Pop();
             currentGameState = gameStateHistory.Peek();
             UpdateSliderBitboards();
-            hasCachedInCheckValue = true;
-            cachedInCheckValue = false;
+            hasCachedInCheckValue = false;
         }
 
 


### PR DESCRIPTION
This PR fixes a bug in the ```ForceSkipTurn()```, ```TrySkipTurn()```, and ```UndoSkipTurn()``` methods. Currently if you use any of these three methods to change the turn and then on that same turn use ```IsInCheck()```, you will always get back false.