### PR TITLE
Make `Board.IsFiftyMoveDraw()` and `Board.IsInStalemate()` public

### DIFF
--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -204,11 +204,18 @@ namespace ChessChallenge.API
         public bool IsDraw()
 		{
 			return IsFiftyMoveDraw() || IsInsufficientMaterial() || IsInStalemate() || IsRepeatedPosition();
-
-			bool IsInStalemate() => !IsInCheck() && GetLegalMoves().Length == 0;
-			bool IsFiftyMoveDraw() => board.currentGameState.fiftyMoveCounter >= 100;
 		}
 
+        	/// <summary>
+        	/// Test if the current position is a draw due to 50-move rule.
+        	/// </summary>
+        	public bool IsFiftyMoveDraw() => board.currentGameState.fiftyMoveCounter >= 100;
+
+        	/// <summary>
+       	 	/// Test if the current position is a draw due to stalemate.
+        	/// </summary>
+       	 	public bool IsInStalemate() => !IsInCheck() && GetLegalMoves().Length == 0;
+		
 		/// <summary>
 		/// Test if the current position has occurred at least once before on the board.
 		/// This includes both positions in the actual game, and positions reached by


### PR DESCRIPTION
[It's being pointed out in the Community Discord](https://discord.com/channels/1132289356011405342/1133449234683801721) that one could want to use `IsDraw()` without checking for stalemates, since doing so can have performance implications.

It may make sense to check for stalemate 'late' in a negamax loop, since a cutoff may happen before ever invoking `.GetLegalMoves()` method.

An easy workaround for that is to make `Board.IsFiftyMoveDraw()` and `Board.IsInStalemate()` public so that we can use them directly, so that's what this PR does.

Obviously it'd be ideal to have an alternative `IsDrawB` method that checks for stalemates to avoid unnecessary token use, but I leave that to you.