### PR TITLE
Add member IsWhiteToMoveInt

### DIFF
--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -290,6 +290,13 @@ namespace ChessChallenge.API
 		{
 			return board.pieceBitboards[PieceHelper.MakePiece((int)pieceType, white)];
 		}
+
+		/// <summary>
+		/// Returns 1 when it is white's turn, and -1 when it is black's.
+		/// </summary>
+		public int IsWhiteToMoveInt => IsWhiteToMove ? 1 : -1;
+
+
 		/// <summary>
 		/// 64-bit number where each bit that is set to 1 represents a square that contains any type of white piece.
 		/// </summary>
@@ -307,6 +314,7 @@ namespace ChessChallenge.API
 
 
 		public bool IsWhiteToMove => board.IsWhiteToMove;
+
 
 		/// <summary>
 		/// Number of ply (a single move by either white or black) played so far


### PR DESCRIPTION
Whilst the `IsWhiteToMove` can be used in boolean logic to determine the colour that is moving, math cannot. `IsWhiteToMoveInt` will fix this by enabling bots to get a number they can multiply against.

For example, when using a numerical evaluation that has white as positive, the bot can multiply against `IsWhiteToMoveInt` at each step in the search tree to find if the evaluation is better for the current player or opponent.