### PR TITLE
Added a max memory usage monitor

### DIFF
--- a/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
+++ b/Chess-Challenge/src/Framework/Application/Core/ChallengeController.cs
@@ -55,6 +55,7 @@ namespace ChessChallenge.Application
         readonly int tokenCount;
         readonly int debugTokenCount;
         readonly StringBuilder pgns;
+        long maxMemoryUsed = 0;
 
         public ChallengeController()
         {
@@ -233,6 +234,10 @@ namespace ChessChallenge.Application
                     moveToPlay = chosenMove;
                     isWaitingToPlayMove = true;
                     playMoveTime = lastMoveMadeTime + MinMoveDelay;
+                    if (PlayerToMove.Bot is MyBot)
+                    {
+                        maxMemoryUsed = Math.Max(ObjectSizeHelper.GetSize(PlayerToMove.Bot), maxMemoryUsed);
+                    }
                 }
                 else
                 {
@@ -389,7 +394,8 @@ namespace ChessChallenge.Application
 
         public void DrawOverlay()
         {
-            BotBrainCapacityUI.Draw(tokenCount, debugTokenCount, MaxTokenCount);
+            BotBrainCapacityUI.DrawTokenUsage(tokenCount, debugTokenCount, MaxTokenCount);
+            BotBrainCapacityUI.DrawMemoryUsage(maxMemoryUsed, MaxMemoryUsage);
             MenuUI.DrawButtons(this);
             MatchStatsUI.DrawMatchStats(this);
         }

--- a/Chess-Challenge/src/Framework/Application/Core/Settings.cs
+++ b/Chess-Challenge/src/Framework/Application/Core/Settings.cs
@@ -20,6 +20,7 @@ namespace ChessChallenge.Application
         // Other settings
         public const int MaxTokenCount = 1024;
         public const LogType MessagesToLog = LogType.All;
+        public const int MaxMemoryUsage = 256 * 1024 * 1024;
 
         public enum LogType
         {

--- a/Chess-Challenge/src/Framework/Application/Helpers/ObjectSizeHelper.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/ObjectSizeHelper.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace ChessChallenge.Application
+{
+    public static class ObjectSizeHelper
+    {
+        static readonly long ObjectSize = IntPtr.Size == 8 ? 24 : 12;
+        static readonly long PointerSize = IntPtr.Size;
+
+        public static long GetSize(object? obj)
+        {
+            if (obj is null)
+            {
+                return 0;
+            }
+
+            var type = obj.GetType();
+
+            // ignore references to the API board
+            if (typeof(API.Board) == type)
+            {
+                return 0;
+            }
+
+            if (type.IsEnum)
+            {
+                var underlyingType = Enum.GetUnderlyingType(type);
+                return Marshal.SizeOf(underlyingType); 
+            }
+            
+            if (type.IsValueType)
+            {
+                // Marshal.SizeOf() does not work for structs with reference types
+                var fieldInfos = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                return fieldInfos.Any(x => x.FieldType.IsClass) 
+                    ? GetFieldsMemorySize(obj, fieldInfos) 
+                    : Marshal.SizeOf(obj);
+            }
+            
+            if (type == typeof(string))
+            {
+                var str = (string)obj;
+                return str.Length * 2 + 6 + ObjectSize;
+            }
+
+            if (obj is IEnumerable enumerable)
+            {
+                return ObjectSize + enumerable.Cast<object>().Sum(item => GetObjectSize(item, item?.GetType() ?? typeof(object)));
+            }
+                
+            if (type.IsClass)
+            {
+                return ObjectSize + GetFieldsMemorySize(obj, type, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            }
+
+            throw new ArgumentException($"Unknown type {type.Name}", nameof(obj));
+        }
+
+        private static long GetFieldsMemorySize(object obj, Type type, BindingFlags bindingFlags) 
+            => GetFieldsMemorySize(obj, type.GetFields(bindingFlags));
+
+        private static long GetFieldsMemorySize(object obj, IEnumerable<FieldInfo> fieldInfos) 
+            => fieldInfos.Sum(x => GetObjectSize(x.GetValue(obj), x.GetType()));
+        
+        private static long GetObjectSize(object? obj, Type type) 
+            => GetSize(obj) + (type.IsClass ? PointerSize : 0);
+    }
+}

--- a/Chess-Challenge/src/Framework/Application/UI/BotBrainCapacityUI.cs
+++ b/Chess-Challenge/src/Framework/Application/UI/BotBrainCapacityUI.cs
@@ -1,4 +1,5 @@
-﻿using Raylib_cs;
+﻿using System;
+using Raylib_cs;
 
 namespace ChessChallenge.Application
 {
@@ -10,31 +11,12 @@ namespace ChessChallenge.Application
         static readonly Color red = new(219, 9, 9, 255);
         static readonly Color background = new Color(40, 40, 40, 255);
 
-        public static void Draw(int totalTokenCount, int debugTokenCount, int tokenLimit)
+        public static void DrawTokenUsage(int totalTokenCount, int debugTokenCount, int tokenLimit)
         {
             int activeTokenCount = totalTokenCount - debugTokenCount;
 
-            int screenWidth = Raylib.GetScreenWidth();
-            int screenHeight = Raylib.GetScreenHeight();
-            int height = UIHelper.ScaleInt(48);
-            int fontSize = UIHelper.ScaleInt(35);
-            // Bg
-            Raylib.DrawRectangle(0, screenHeight - height, screenWidth, height, background);
-            // Bar
+            int startPos = Raylib.GetScreenWidth() / 2;
             double t = (double)activeTokenCount / tokenLimit;
-
-            Color col;
-            if (t <= 0.7)
-                col = green;
-            else if (t <= 0.85)
-                col = yellow;
-            else if (t <= 1)
-                col = orange;
-            else
-                col = red;
-            Raylib.DrawRectangle(0, screenHeight - height, (int)(screenWidth * t), height, col);
-
-            var textPos = new System.Numerics.Vector2(screenWidth / 2, screenHeight - height / 2);
             string text = $"Bot Brain Capacity: {activeTokenCount}/{tokenLimit}";
             if (activeTokenCount > tokenLimit)
             {
@@ -44,7 +26,57 @@ namespace ChessChallenge.Application
             {
                 text += $"    ({totalTokenCount} with Debugs included)";
             }
+            Draw(text, t, startPos);
+        }
+        
+        public static void DrawMemoryUsage(long memorySize, long memoryLimit)
+        {
+            int startPos = 0;
+            double t = (double)memorySize / memoryLimit;
+            string text = $"Bot Memory Capacity: {FriendlySize(memorySize)} / {FriendlySize(memoryLimit)}";
+            if (memorySize > memoryLimit)
+            {
+                text += " [LIMIT EXCEEDED]";
+            }
+            Draw(text, t, startPos);
+        }
+        
+        static void Draw(string text, double t, int startPos)
+        {
+            int barWidth = Raylib.GetScreenWidth() / 2;
+            int screenHeight = Raylib.GetScreenHeight();
+            int barHeight = UIHelper.ScaleInt(48);
+            int fontSize = UIHelper.ScaleInt(35);
+            // Bg
+            Raylib.DrawRectangle(startPos, screenHeight - barHeight, startPos + barWidth, barHeight, background);
+            // Bar
+            Color col;
+            if (t <= 0.7)
+                col = green;
+            else if (t <= 0.85)
+                col = yellow;
+            else if (t <= 1)
+                col = orange;
+            else
+                col = red;
+            
+            Raylib.DrawRectangle(startPos, screenHeight - barHeight, startPos + (int)(barWidth * Math.Min(t, 1)), barHeight, col);
+
+            var textPos = new System.Numerics.Vector2(startPos + barWidth / 2, screenHeight - barHeight / 2);
             UIHelper.DrawText(text, textPos, fontSize, 1, Color.WHITE, UIHelper.AlignH.Centre);
+        }
+        
+        static readonly string[] sizes = { "B", "KB", "MB" };
+        static string FriendlySize(long size)
+        {
+            double friendlySize = size;
+            int order = 0;
+            while (friendlySize >= 1024 && order < sizes.Length - 1)
+            {
+                order++;
+                friendlySize /= 1024;
+            }
+            return $"{friendlySize:0.##} {sizes[order]}";
         }
     }
 }


### PR DESCRIPTION
Added support to monitor the bot's memory usage. Trying to solve #396

Since the framework does not natively support calculation of memory usage of a single object,
I used reflection to calculate the size of each reachable object through MyBot.
Depending on the memory structures used, it can be quite slow (reflection).

Not sure if the remaining time is affected for the other bot (EvilBot).

Also, "cheaters" can still access static objects that are not contained within MyBot. Those won't be factored into the memory usage.

Initially I wanted to have two stacked bars, but the height of the board has too many hard code values here and there.
So I split the bar in two :)

![image](https://github.com/SebLague/Chess-Challenge/assets/701534/de2d7cbf-f209-4a46-a7a3-828cbfdbe8cd)

