### PR TITLE
Fix typo in comment

### DIFF
--- a/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
+++ b/Chess-Challenge/src/Framework/Application/Helpers/Token Counter/TokenCounter.cs
@@ -20,7 +20,7 @@ namespace ChessChallenge.Application
             SyntaxKind.SemicolonToken,
             SyntaxKind.CommaToken,
             SyntaxKind.ReadOnlyKeyword,
-            // only count open brace since I want to count the pair as a single token
+            // only count closing brace since I want to count the pair as a single token
             SyntaxKind.CloseBraceToken, 
             SyntaxKind.CloseBracketToken,
             SyntaxKind.CloseParenToken


### PR DESCRIPTION
Comment said only checking open brace but code shows checking close brace. Update comment to match.