### PR TITLE
Add HasCastled in BoardAPI

### DIFF
--- a/Chess-Challenge/src/API/Board.cs
+++ b/Chess-Challenge/src/API/Board.cs
@@ -160,6 +160,12 @@ namespace ChessChallenge.API
 		}
 
 		/// <summary>
+		/// Does the given player has castled?
+		/// (this will only detect castled made during the game moves)
+		/// </summary>
+		public bool HasCastled(bool white) => white ? board.currentGameState.hasWhiteCastled : board.currentGameState.hasBlackCastled;
+
+		/// <summary>
 		/// Does the given player still have the right to castle kingside?
 		/// Note that having the right to castle doesn't necessarily mean castling is legal right now
 		/// (for example, a piece might be in the way, or player might be in check, etc).

--- a/Chess-Challenge/src/Framework/Chess/Board/Board.cs
+++ b/Chess-Challenge/src/Framework/Chess/Board/Board.cs
@@ -139,6 +139,9 @@ namespace ChessChallenge.Chess
             int newCastlingRights = currentGameState.castlingRights;
             int newEnPassantFile = 0;
 
+            bool hasWhiteCastled = currentGameState.hasWhiteCastled || IsWhiteToMove && move.MoveFlag == Move.CastleFlag;
+            bool hasBlackCastled = currentGameState.hasBlackCastled || !IsWhiteToMove && move.MoveFlag == Move.CastleFlag;
+
             // Update bitboard of moved piece (pawn promotion is a special case and is corrected later)
             MovePiece(movedPiece, startSquare, targetSquare);
 
@@ -272,7 +275,7 @@ namespace ChessChallenge.Chess
                 newFiftyMoveCounter = 0;
             }
 
-            GameState newState = new(capturedPieceType, newEnPassantFile, newCastlingRights, newFiftyMoveCounter, newZobristKey);
+            GameState newState = new(capturedPieceType, newEnPassantFile, newCastlingRights, hasWhiteCastled, hasBlackCastled, newFiftyMoveCounter, newZobristKey);
             gameStateHistory.Push(newState);
             currentGameState = newState;
             hasCachedInCheckValue = false;
@@ -395,7 +398,7 @@ namespace ChessChallenge.Chess
             newZobristKey ^= Zobrist.sideToMove;
             newZobristKey ^= Zobrist.enPassantFile[currentGameState.enPassantFile];
 
-            GameState newState = new(PieceHelper.None, 0, currentGameState.castlingRights, currentGameState.fiftyMoveCounter + 1, newZobristKey);
+            GameState newState = new (PieceHelper.None, 0, currentGameState.castlingRights, currentGameState.hasWhiteCastled, currentGameState.hasBlackCastled, currentGameState.fiftyMoveCounter + 1, newZobristKey);
             currentGameState = newState;
             gameStateHistory.Push(currentGameState);
             UpdateSliderBitboards();
@@ -510,9 +513,9 @@ namespace ChessChallenge.Chess
             plyCount = (posInfo.moveCount - 1) * 2 + (IsWhiteToMove ? 0 : 1);
 
             // Set game state (note: calculating zobrist key relies on current game state)
-            currentGameState = new GameState(PieceHelper.None, posInfo.epFile, castlingRights, posInfo.fiftyMovePlyCount, 0);
+            currentGameState = new GameState(PieceHelper.None, posInfo.epFile, castlingRights, false, false, posInfo.fiftyMovePlyCount, 0);
             ulong zobristKey = Zobrist.CalculateZobristKey(this);
-            currentGameState = new GameState(PieceHelper.None, posInfo.epFile, castlingRights, posInfo.fiftyMovePlyCount, zobristKey);
+            currentGameState = new GameState(PieceHelper.None, posInfo.epFile, castlingRights, false, false, posInfo.fiftyMovePlyCount, zobristKey);
 
             RepetitionPositionHistory.Push(zobristKey);
 

--- a/Chess-Challenge/src/Framework/Chess/Board/GameState.cs
+++ b/Chess-Challenge/src/Framework/Chess/Board/GameState.cs
@@ -5,6 +5,8 @@
         public readonly int capturedPieceType;
         public readonly int enPassantFile;
         public readonly int castlingRights;
+        public readonly bool hasWhiteCastled;
+        public readonly bool hasBlackCastled;
         public readonly int fiftyMoveCounter;
         public readonly ulong zobristKey;
 
@@ -13,11 +15,13 @@
         public const int ClearBlackKingsideMask = 0b1011;
         public const int ClearBlackQueensideMask = 0b0111;
 
-        public GameState(int capturedPieceType, int enPassantFile, int castlingRights, int fiftyMoveCounter, ulong zobristKey)
+        public GameState(int capturedPieceType, int enPassantFile, int castlingRights, bool hasWhiteCastled, bool hasBlackCastled, int fiftyMoveCounter, ulong zobristKey)
         {
             this.capturedPieceType = capturedPieceType;
             this.enPassantFile = enPassantFile;
             this.castlingRights = castlingRights;
+            this.hasWhiteCastled = hasWhiteCastled;
+            this.hasBlackCastled = hasBlackCastled;
             this.fiftyMoveCounter = fiftyMoveCounter;
             this.zobristKey = zobristKey;
         }


### PR DESCRIPTION
A pull request to implement HasCastled feature from https://github.com/SebLague/Chess-Challenge/issues/258 and https://github.com/SebLague/Chess-Challenge/issues/286.

I know there is board.GameMoveHistory to help, but since this game history is not updated during bot search, this force to track internally the status of each game. So I think we should have this feature by default in the API.
